### PR TITLE
fix(auto-merge): match pre-release tokens against values, not the raw JSON

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,13 +38,38 @@ jobs:
           UPDATED_JSON: ${{ steps.meta.outputs.updated-dependencies-json }}
         run: |
           set -euo pipefail
-          pattern='[-._]?(rc|alpha|beta|dev|pre|preview|snapshot|nightly|canary|next|insiders)'
+          # A token counts only where it is not buried inside a longer alphabetic word: `3.15.0rc1`
+          # is held, while `26.7.0-alpine` and `1.31-alpine` are ordinary releases and pass. Longest
+          # alternatives first so `preview` is reported as itself rather than as `pre`.
+          pattern='(^|[^a-zA-Z])(preview|insiders|snapshot|nightly|canary|alpha|beta|next|dev|pre|rc)([^a-zA-Z]|$)'
           held=false
-          if printf '%s' "$NEW_VERSION" | grep -qiE "$pattern"; then held=true; fi
-          if printf '%s' "$UPDATED_JSON" | grep -qiE "\"[^\"]*$pattern[^\"]*\""; then held=true; fi
+          offender=""
+          if [ -n "${NEW_VERSION:-}" ] && printf '%s' "$NEW_VERSION" | grep -qiE "$pattern"; then
+            held=true
+            offender="$NEW_VERSION"
+          fi
+          if [ -n "${UPDATED_JSON:-}" ]; then
+            # jq ships on GitHub-hosted runners. On a self-hosted one without it this holds every
+            # PR, so say which of the two failures it is -- an unexplained fleet-wide freeze is
+            # exactly how the 0.1.18 bug went unnoticed for a day.
+            if ! command -v jq >/dev/null 2>&1; then
+              held=true
+              offender="jq unavailable - cannot inspect grouped metadata"
+            elif versions=$(printf '%s' "$UPDATED_JSON" | jq -r '.[]?.newVersion // empty'); then
+              hit=$(printf '%s\n' "$versions" | grep -iE "$pattern" | head -n 1 || true)
+              if [ -n "$hit" ]; then
+                held=true
+                offender="$hit"
+              fi
+            else
+              held=true
+              offender="unparseable metadata"
+            fi
+          fi
           echo "held=$held" >> "$GITHUB_OUTPUT"
+          echo "offender=$offender" >> "$GITHUB_OUTPUT"
           if [ "$held" = true ]; then
-            echo "pre-release target detected (new-version='$NEW_VERSION') - not auto-merging."
+            echo "pre-release target detected ('$offender') - not auto-merging."
           fi
 
       - name: Explain a held pre-release
@@ -52,9 +77,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+          # The offending VALUE, not `new-version` -- which is empty on exactly the
+          # grouped PRs the metadata check exists to cover.
+          OFFENDER: ${{ steps.prerelease.outputs.offender }}
         run: |
-          gh pr comment "$PR_URL" --body "Held: this bump targets a **pre-release** version (\`$NEW_VERSION\`). Every other update type auto-merges; pre-releases need a human to confirm it is intended."
+          gh pr comment "$PR_URL" --body "Held: this bump targets a **pre-release** version (\`$OFFENDER\`). Every other update type auto-merges; pre-releases need a human to confirm it is intended."
 
       - name: Wait for required checks, then merge
         if: ${{ steps.prerelease.outputs.held == 'false' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Install Dependencies
         run: yarn install --immutable
 
+      # ci.yml is pull_request-only, so before this step a DIRECT push to master reached
+      # production without ever being linted -- the gate existed, but not on the path that
+      # actually ships. Accepted cost, decided deliberately: a lint failure now blocks the
+      # deploy. Ordered before the tests so a style failure reports in seconds.
+      - name: Lint
+        run: yarn lint
+
       - name: Run Tests
         run: yarn test
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://trencho.github.io/",
   "type": "module",
-  "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae",
+  "packageManager": "yarn@4.18.0+sha512.fcb8716fe7cd0eece141ffc18b92193a9df9204c1ba83189c288835223fc0bbe64af473bab0d5e9927a7daeb5caf2bb07eb2787cc9338ca040ea125f2a1f2f7e",
   "scripts": {
     "predeploy": "yarn build",
     "deploy": "gh-pages -d dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4922,7 +4922,7 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>":
   version: 2.0.0-next.7
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.7#optional!builtin<compat/resolve>::version=2.0.0-next.7&hash=9bd1a5"
   dependencies:
     es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.2"
@@ -4932,7 +4932,7 @@ __metadata:
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/6bb6f1d8a1789f7a5b4e35d950e76bc0ba632ff7d51fe86b6f34fb5f41e1ce0f7b884ec166828cfc0728ddffeaee49527711d752d12398297f90c51acd22195e
+  checksum: 10c0/911e8321c64ec2a723247dbeabfcb7663577adf52af642bfda61ddee686fbef2255ad529ff57ee8e3884ee23186b85b2637988bfafc0a9a3a81a98bd4af1e2fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The 0.1.18 guard held every Dependabot PR in the fleet. Its second check --
added because `new-version` is empty on a grouped PR -- grepped the raw
`updated-dependencies-json` blob, which always contains the key "prevVersion".
"prevVersion" contains "pre", so the match succeeded on every pull request, on
every repo, forever.

Seven PRs were stuck across three public repos before a run log was read; the
six private repos hid the rest, because Dependabot cannot get a runner there
anyway. task-manager-frontend#33 carries the bot's own evidence: "Held: this
bump targets a pre-release version (`1.31-alpine`)".

Two defects in one predicate:

- It scanned keys as well as values. It now extracts only newVersion values via
  jq, which also stops "dependencyType":"direct:development" reading as a `dev`
  pre-release.
- `[-._]?(rc|...)` made every token an unanchored substring, so it could never
  tell a channel marker from an ordinary word. A token now counts only outside a
  longer alphabetic word: 3.15.0rc1 is held, 26.7.0-alpine is not.

Failing toward holding is unchanged. A missing jq still holds everything but now
says so distinctly rather than looking like unparseable metadata -- an
unexplained fleet-wide freeze is exactly how this survived a day.

Adds scripts/test-prerelease-guard.sh (53 assertions), which extracts the real
step body out of both templates and executes it, so it tests the shipped text
rather than a copy that drifts from it. Mutation-verified: reverting the
predicate, dropping `rc`, and disabling the metadata check are each caught.

Also documents the manifest-vs-lock CI check (a compiled lock that drifts from
its manifest makes the OSV scan report green while auditing a tree nobody
installs) and corrects the cleanup template on Maven: Dependabot does bump the
maven-wrapper artifact, but not the distributionUrl that sets the Maven version.
