### PR TITLE
fix(auto-merge): handle a branch that falls behind DURING the wait

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -133,7 +133,24 @@ jobs:
             done <<< "$REQUIRED_CHECKS"
             if [ "$pending" -eq 1 ]; then echo "waiting for required checks..."; sleep 20; continue; fi
             echo "all required checks green — merging."
-            gh pr merge "$PR_URL" --squash --delete-branch
-            exit 0
+            if gh pr merge "$PR_URL" --squash --delete-branch; then
+              exit 0
+            fi
+            # The merge can be refused because the branch fell behind DURING the wait above. The
+            # BEHIND check before this loop cannot see that: a sibling PR landing mid-loop is the
+            # common case, not an edge one, and recreating several Dependabot PRs at once
+            # guarantees it. Hand it back to Dependabot rather than failing the run -- a branch
+            # updated with GITHUB_TOKEN would get no CI on the new head (the same anti-recursion
+            # rule as above) and could never satisfy the gate.
+            state=$(gh pr view "$PR_URL" --json mergeStateStatus --jq .mergeStateStatus)
+            if [ "$state" = "BEHIND" ]; then
+              gh pr comment "$PR_URL" --body '@dependabot rebase'
+              echo "merge refused: branch fell behind during the wait; asked Dependabot to rebase."
+              exit 0
+            fi
+            # Any other refusal is real and must stay loud. One seen in the wild: GitHub blocks a
+            # GITHUB_TOKEN merge of a PR that edits a workflow file ("refusing to allow a GitHub
+            # App to create or update workflow ... without `workflows` permission").
+            echo "merge refused while mergeStateStatus=$state."; exit 1
           done
           echo "timed out waiting for required checks."; exit 1


### PR DESCRIPTION
The self-gated workflow reads mergeStateStatus once, before its ~20-minute wait
loop, and asks Dependabot to rebase if the branch is behind. But a sibling PR can
land during the wait -- and then the merge at the end of the loop is refused
("Required status check `build` is expected") and the job exits 1, with the
rebase handler sitting uselessly above the loop.

This is the common case, not an edge one: recreating several Dependabot PRs at
once guarantees it. It cost a failed run on trencho.github.io#22 within an hour
of 0.1.20 landing -- which is itself the pattern worth noting, since fixing the
thing that blocked everything is what exposes the next defect.

gh pr merge is now tested, and on refusal the state is re-read: BEHIND asks
Dependabot to rebase and exits 0, anything else still fails loudly. A pre-merge
re-check was considered and rejected: it narrows the race without closing it,
whereas handling the refusal closes it.

Only the self-gated variant is affected -- the native variant hands BEHIND to
GitHub, which resolves it (task-manager-frontend#32 sat at BEHIND and merged
unaided). Three repos run the self-gated workflow, not the six recorded
yesterday; that note was wrong.

Adds a CI ordering assertion, because the bug is purely WHERE the second BEHIND
check sits: the template must carry two, and the last must follow the merge call.
Mutation-verified.
