### PR TITLE
ci: fix the monthly jobs' schedule and their report steps

### DIFF
--- a/.github/workflows/dependency-cleanup.yml
+++ b/.github/workflows/dependency-cleanup.yml
@@ -22,7 +22,11 @@ name: Dependency cleanup
 
 on:
   schedule:
-    - cron: "0 8 1-7 * 1" # first Monday of the month, 08:00 UTC — after the weekly bumps have landed
+    # WEEKLY, gated to the first week by the `gate` job below — NOT "0 8 1-7 * 1".
+    # cron ORs a restricted day-of-month with a restricted day-of-week, so `1-7 * 1` reads
+    # "days 1-7 OR every Monday" and fires ~5 times a month. Observed 2026-08-17 (a Monday
+    # outside the first week) on all nine repos running this job.
+    - cron: "0 8 * * 1" # Mondays, 08:00 UTC — after the weekly bumps have landed
   workflow_dispatch:
 
 permissions:
@@ -34,8 +38,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The schedule above fires every Monday; this decides whether it is the first one of the month.
+  # It exists because cron cannot express "first Monday" — see the note on the schedule.
+  gate:
+    name: First-week gate
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.week.outputs.run }}
+    steps:
+      - name: Is this the first week?
+        id: week
+        run: |
+          # A manual dispatch is NEVER date-gated: you asked for it, you get it.
+          #
+          # `%-d` is UNPADDED and the test is plain `[ ]`, not `[[ ]]`/`(( ))`, both on purpose.
+          # `%d` yields "08"/"09" and bash reads a leading zero as octal in arithmetic contexts,
+          # so `[[ 08 -le 7 ]]` dies with "value too great for base". At THIS threshold the error
+          # happens to land on the answer we wanted anyway (day 8 skips either way), so it is a
+          # fragility rather than a live bug -- but it prints an error twice a month and turns
+          # into a wrong answer the moment the window moves (`[[ 09 -le 10 ]]` errors to false).
+          # Unpadded input compared with `[ ]` is base-10 and correct at any threshold.
+          if [ "${{ github.event_name }}" != "schedule" ] || [ "$(date -u +%-d)" -le 7 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Not the first week of the month; skipping the monthly report." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   cleanup:
     name: Dependency cleanup
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -63,6 +96,13 @@ jobs:
       # --- (A) Node / TypeScript ---
       - uses: actions/setup-node@v7
         with: { node-version: '24' }
+      - name: Install dependencies (knip needs them resolved)
+        run: |
+          corepack enable || true
+          if [ -f yarn.lock ]; then yarn install --immutable
+          elif [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile
+          else npm ci; fi
+
       - name: Unused dependencies (knip)
         run: |
           echo -e "\n## Unused dependencies (knip)\n" >> report.md
@@ -217,11 +257,24 @@ jobs:
             if [ -n "$pinned" ]; then
               found=1
               name=${pinned%@*}; have=${pinned#*@}; have=${have%%+*}
+
+              # WHICH PACKAGE CARRIES THE LINE YOU ARE ON. `yarn` on npm is Yarn *classic* and its
+              # latest is 1.22.22 — frozen since 2024. Yarn 2+ ("Berry") ships as `@yarnpkg/cli`.
+              # Querying `yarn` for a Berry repo reports 4.18.0 as behind 1.22.22 and recommends a
+              # DOWNGRADE across three majors, which would break the repo. Observed 2026-08-17.
+              query=$name
+              if [ "$name" = "yarn" ] && [ "${have%%.*}" -ge 2 ] 2>/dev/null; then
+                query="@yarnpkg/cli"
+              fi
+
               # `|| true` on every probe: `pipefail` is on, so an offline registry or a grep with
               # no match would otherwise fail the step and lose the whole report.
-              latest=$(npm view "$name" version 2>/dev/null || true)
-              if [ -n "$latest" ] && [ "$have" != "$latest" ]; then
-                echo "- \`packageManager\`: **$name@$have** -> latest **$latest**." >> report.md
+              latest=$(npm view "$query" version 2>/dev/null || true)
+              if [ -z "$latest" ]; then
+                # A lookup that could not run must never print as a recommendation.
+                echo "- \`packageManager\`: \`$pinned\` — could not reach the registry for \`$query\`." >> report.md
+              elif [ "$have" != "$latest" ]; then
+                echo "- \`packageManager\`: **$name@$have** -> latest **$latest** (from \`$query\`)." >> report.md
                 echo "  Update with \`corepack use $name@$latest\` (Dependabot cannot: dependabot-core#4830)." >> report.md
               else
                 echo "- \`packageManager\`: \`$pinned\` is current." >> report.md
@@ -233,13 +286,22 @@ jobs:
           if [ -f "$wrapper" ]; then
             found=1
             have=$(grep -oP '(?<=apache-maven-)[0-9.]+(?=-bin)' "$wrapper" 2>/dev/null | head -1 || true)
+
+            # NEITHER `<latest>` NOR `<release>` IS NECESSARILY STABLE. Central currently reports
+            # both as `4.0.0-rc-6` for apache-maven, so reading either recommends a release
+            # candidate for production builds (observed 2026-08-17). Take the version list, drop
+            # anything carrying a pre-release token, and pick the highest that remains.
             latest=$(curl -fsSL https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml 2>/dev/null \
-                     | grep -oP '(?<=<release>)[^<]+' | head -1 || true)
-            if [ -n "$latest" ] && [ "$have" != "$latest" ]; then
-              echo "- Maven wrapper: **$have** -> latest **$latest**. Update with \`./mvnw wrapper:wrapper -Dmaven=$latest\`." >> report.md
+                     | grep -oP '(?<=<version>)[^<]+' \
+                     | grep -vEi -- '-(rc|alpha|beta|m|milestone|preview|snapshot)' \
+                     | sort -V | tail -1 || true)
+            if [ -z "$latest" ]; then
+              echo "- Maven wrapper: \`$have\` — could not resolve a stable release from Central." >> report.md
+            elif [ "$have" != "$latest" ]; then
+              echo "- Maven wrapper: **$have** -> newest **stable** **$latest**. Update with \`./mvnw wrapper:wrapper -Dmaven=$latest\`." >> report.md
               echo "  (Dependabot support merged 2026-08-11 but is flag-gated off — adopt it when it ships and drop this check.)" >> report.md
             else
-              echo "- Maven wrapper: \`$have\` is current." >> report.md
+              echo "- Maven wrapper: \`$have\` is the newest stable release." >> report.md
             fi
           fi
 


### PR DESCRIPTION
Rolled from **claude-workbench 0.1.27**. The first month these jobs actually ran anywhere exposed five defects in the shipped templates — this repo carries them.

### The schedule was not monthly
`0 8 1-7 * 1` ORs a restricted day-of-month with a restricted day-of-week, so it reads *days 1–7 **or** every Monday*. It fired on **Monday 2026-08-17**, outside the first week. Now scheduled weekly and gated to the first week by a `gate` job the real job `needs:`; a `workflow_dispatch` is never date-gated.

### The package-manager check recommended a downgrade and a release candidate
`yarn` on npm is Yarn *classic*, frozen at 1.22.22 — Berry ships as `@yarnpkg/cli`, so a Yarn 4 repo was told to "update" three majors backwards. And Central reports an RC in both `<latest>` and `<release>` for apache-maven, so either recommended `4.0.0-rc-6`. Both fixed; a lookup that cannot run now says so instead of recommending.

### The unused-dependency step never produced a report
knip resolves imports through `node_modules` (so it needs an install), `deptry .` cannot see a layered `requirements/` directory, and `./mvnw` is often committed non-executable. Whichever block this repo uses is fixed.

Covered from now on by `scripts/test-cleanup-report.sh` in the workbench (30 assertions, mutation-verified six ways), which extracts these step bodies out of the shipped template and **executes** them rather than testing a copy that drifts.