### PR TITLE
ci: stop the unused-dependency detector writing ANSI escapes into the issue

### DIFF
--- a/.github/workflows/dependency-cleanup.yml
+++ b/.github/workflows/dependency-cleanup.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           echo -e "\n## Unused dependencies (knip)\n" >> report.md
           echo '```' >> report.md
-          npx --yes knip@5 --no-exit-code --reporter compact >> report.md 2>&1 || true
+          NO_COLOR=1 npx --yes knip@5 --no-exit-code --reporter compact >> report.md 2>&1 || true
           echo '```' >> report.md
 
       # ============================================================================================


### PR DESCRIPTION
Rolled from **claude-workbench 0.1.28**, found by reading the reports the previous fix produced.

knip and deptry colour their output even though a runner is not a TTY, and the report lands in a **GitHub issue**, where ANSI is not styling — it is litter inside each finding:

```
^[[1mrequirements.txt^[[m^[[36m:^[[m ^[[1m^[[31mDEP002^[[m 'black' defined as a dependency but not used
```

`NO_COLOR=1` for knip, `--no-ansi` for deptry. Covered by an assertion in the workbench's `test-cleanup-report.sh`.

This was invisible until the previous PR made the detectors run at all — a defect can hide behind a louder one.