### PR TITLE
fix(deps): track @types/node to the runtime major, and hold it there

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # @types/node tracks the RUNTIME major, always -- typings for a Node the project does
+      # not run describe APIs that are not there. It had reached 26.2.0 while every runtime
+      # pin here says 24. A runtime-image hold cannot reach an npm package, so without this
+      # one the types walk to the next major alone; both lift on the same condition.
+      # lift-when: eol-lts nodejs 26
+      - dependency-name: "@types/node"
+        versions: [">=25"]
       # ESLint 10 breaks eslint-plugin-react (removed context.getFilename()) — held until the
       # plugin ships an ESLint-10-compatible release.
       - dependency-name: "eslint"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.4",
-    "@types/node": "26.2.0",
+    "@types/node": "24.13.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@types/react-google-recaptcha": "2.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,12 +1436,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:26.2.0":
-  version: 26.2.0
-  resolution: "@types/node@npm:26.2.0"
+"@types/node@npm:24.13.3":
+  version: 24.13.3
+  resolution: "@types/node@npm:24.13.3"
   dependencies:
-    undici-types: "npm:~8.3.0"
-  checksum: 10c0/f8566d88162241eb55a46f7e4ea097188eab0aaafefea7a58e63adab8c4144eb98c08b7911452c846104c339a0f82282f5e1ed4b26b578d60709614fe2843f4d
+    undici-types: "npm:~7.18.0"
+  checksum: 10c0/a5bc08f49b9581dcdca90e02cd77197a3c799840807664942e5cd5161a553d4d2ae8064f7e3294410d748d7d098b5c1848be7fa50c06f29c4193ab16be4e59eb
   languageName: node
   linkType: hard
 
@@ -4637,7 +4637,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:7.0.1"
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.4"
-    "@types/node": "npm:26.2.0"
+    "@types/node": "npm:24.13.3"
     "@types/react": "npm:19.2.18"
     "@types/react-dom": "npm:19.2.4"
     "@types/react-google-recaptcha": "npm:2.1.9"
@@ -5891,10 +5891,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~8.3.0":
-  version: 8.3.0
-  resolution: "undici-types@npm:8.3.0"
-  checksum: 10c0/c8aa7e2fbebfce519654dafadc0ece59be888d2ccaf180fb4495da875e7b536d2456345c384069c7e6f3e9c9ab7435f074957da306f142343eee86ff8048855a
+"undici-types@npm:~7.18.0":
+  version: 7.18.2
+  resolution: "undici-types@npm:7.18.2"
+  checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@types/node` had reached **26.2.0** while every runtime pin here says **Node 24** (`.nvmrc`, CI, deploy, security-scan). Typings for a Node the project does not run describe APIs that are not there.

**Why it drifted:** a runtime hold lives in the `docker` ecosystem and cannot reach an npm package, so `@types/node` kept moving alone. Paired-hold convention from workbench `0.1.27`; this repo was one of three that missed it.

- pinned to **24.13.3** (newest 24.x, resolved live)
- paired npm hold with `# lift-when: eol-lts nodejs 26`

**Verified:** `yarn install --immutable` clean, then **lint, test and build all green**.