### PR TITLE
ci: pin actions-gh-pages to its major tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
`peaceiris/actions-gh-pages` was pinned at `@v4.1.0` — the only patch-pinned action here. The fleet convention is a **major tag**, which still receives Dependabot bumps but does not read as stale the moment a patch ships.

**The tag was verified to exist before changing it.** That is not a formality: in this same pass I moved `google/osv-scanner-action` to `@v2` on the same convention and broke two workflows — that action publishes only exact `v2.x.y` tags, so `@v2` is a 404 (`unable to find version v2`). `peaceiris/actions-gh-pages` genuinely does publish a floating `v4`.