### PR TITLE
fix(contact): actually verify the reCAPTCHA token

### DIFF
--- a/src/components/Contact.test.tsx
+++ b/src/components/Contact.test.tsx
@@ -135,11 +135,16 @@ describe('Contact form submission', () => {
     expect(
       await screen.findByText(/message has been sent successfully/i),
     ).toBeInTheDocument();
-    expect(sendEmailMock).toHaveBeenCalledWith({
-      name: 'Ada',
-      email: 'ada@example.com',
-      message: 'This is a valid message.',
-    });
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      {
+        name: 'Ada',
+        email: 'ada@example.com',
+        message: 'This is a valid message.',
+      },
+      // The captcha token is forwarded so EmailJS can verify it server-side. Asserted here
+      // because a silently-dropped token is exactly the defect this argument exists to prevent.
+      'test-token',
+    );
   });
 
   it('surfaces an error and keeps the form when sending fails', async () => {

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
 import { ToastContainer } from 'react-toastify';
 import { sendEmail } from '@/services/emailService';
@@ -10,6 +10,7 @@ import {
   FaEnvelope,
   FaUser,
 } from 'react-icons/fa';
+import type ReCAPTCHA from 'react-google-recaptcha';
 import LazyReCAPTCHA from './LazyReCAPTCHA';
 import { showError, showSuccess } from '@/utils/toastUtils';
 import { fadeInUp } from '@/utils/animationVariants';
@@ -82,6 +83,8 @@ const Contact = () => {
 
   const [submitted, setSubmitted] = useState(false);
   const [captchaValue, setCaptchaValue] = useState<string | null>(null);
+  // Held so a spent token can be cleared from the widget itself, not just from React state.
+  const recaptchaRef = useRef<ReCAPTCHA | null>(null);
   const [showMessage, setShowMessage] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -145,6 +148,7 @@ const Contact = () => {
   const handleReset = () => {
     setFormData({ name: '', email: '', message: '' });
     setErrors({});
+    recaptchaRef.current?.reset();
     setCaptchaValue(null);
     setSubmitted(false);
     setShowMessage(false);
@@ -166,7 +170,7 @@ const Contact = () => {
     setIsSubmitting(true);
 
     try {
-      const result = await sendEmail(formData);
+      const result = await sendEmail(formData, captchaValue);
 
       if (result.success) {
         setSubmitted(true);
@@ -176,6 +180,12 @@ const Contact = () => {
           darkMode,
         );
       } else {
+        // A reCAPTCHA token is single-use and short-lived. On a failure the form stays mounted, so
+        // without clearing this the next attempt would resubmit a token the server has already
+        // seen -- which fails verification and looks like the send is broken rather than the token
+        // being spent. Clearing it forces a fresh challenge, which is what the retry needs.
+        recaptchaRef.current?.reset();
+        setCaptchaValue(null);
         showError(
           `Failed to send message: ${result.error}. Please try again or contact me directly.`,
           darkMode,
@@ -183,6 +193,8 @@ const Contact = () => {
       }
     } catch (error) {
       console.error('Form submission error:', error);
+      recaptchaRef.current?.reset();
+      setCaptchaValue(null);
       showError('An unexpected error occurred. Please try again.', darkMode);
     } finally {
       setIsSubmitting(false);
@@ -352,6 +364,7 @@ const Contact = () => {
             variants={fadeInUp}
           >
             <LazyReCAPTCHA
+              widgetRef={recaptchaRef}
               onChange={handleCaptchaChange}
               theme={darkMode ? 'dark' : 'light'}
             />

--- a/src/components/LazyReCAPTCHA.tsx
+++ b/src/components/LazyReCAPTCHA.tsx
@@ -6,9 +6,19 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 interface LazyReCAPTCHAProps {
   onChange: (value: string | null) => void;
   theme?: 'light' | 'dark';
+  // Forwarded to the widget so a caller can `.reset()` it. A reCAPTCHA token is single-use, so a
+  // form that stays mounted after a failed submit has to clear the widget as well as its own state
+  // -- otherwise the checkbox still reads as solved while the token behind it is spent.
+  // Named explicitly rather than taking `ref`, because this component already puts a ref on its
+  // own wrapper div and one `ref` meaning two things would be a trap.
+  widgetRef?: React.RefObject<ReCAPTCHA | null>;
 }
 
-const LazyReCAPTCHA = ({ onChange, theme = 'dark' }: LazyReCAPTCHAProps) => {
+const LazyReCAPTCHA = ({
+  onChange,
+  theme = 'dark',
+  widgetRef,
+}: LazyReCAPTCHAProps) => {
   const siteKey = config.recaptcha.siteKey;
   const [isLoaded, setIsLoaded] = useState(false);
   const [ReCAPTCHAComponent, setReCAPTCHAComponent] = useState<
@@ -57,7 +67,7 @@ const LazyReCAPTCHA = ({ onChange, theme = 'dark' }: LazyReCAPTCHAProps) => {
         </div>
       ) : ReCAPTCHAComponent ? (
         <ReCAPTCHAComponent
-          // className="mb-4 sm:mb-6 scale-[0.75] sm:scale-[0.85] md:scale-[1]"
+          ref={widgetRef}
           sitekey={siteKey}
           onChange={onChange}
           theme={theme}

--- a/src/services/emailService.test.ts
+++ b/src/services/emailService.test.ts
@@ -20,11 +20,14 @@ describe('sendEmail', () => {
   it('forwards the form data to emailjs.send and returns success', async () => {
     mockedSend.mockResolvedValue({ status: 200, text: 'OK' });
 
-    const result = await sendEmail({
-      name: 'Ada',
-      email: 'ada@example.com',
-      message: 'Hello there',
-    });
+    const result = await sendEmail(
+      {
+        name: 'Ada',
+        email: 'ada@example.com',
+        message: 'Hello there',
+      },
+      'captcha-token',
+    );
 
     expect(result.success).toBe(true);
     expect(mockedSend).toHaveBeenCalledTimes(1);
@@ -36,17 +39,23 @@ describe('sendEmail', () => {
       email: 'ada@example.com',
       message: 'Hello there',
       to_name: 'Aleksandar Trenchevski',
+      // EmailJS looks for this exact field name when template-side reCAPTCHA verification is
+      // enabled. Dropping it silently turns the challenge back into decoration, so it is asserted.
+      'g-recaptcha-response': 'captcha-token',
     });
   });
 
   it('returns a failure result when emailjs.send rejects', async () => {
     mockedSend.mockRejectedValue(new Error('network down'));
 
-    const result = await sendEmail({
-      name: 'Ada',
-      email: 'ada@example.com',
-      message: 'Hello there',
-    });
+    const result = await sendEmail(
+      {
+        name: 'Ada',
+        email: 'ada@example.com',
+        message: 'Hello there',
+      },
+      'captcha-token',
+    );
 
     expect(result).toEqual({ success: false, error: 'network down' });
   });

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -20,8 +20,22 @@ export type EmailResult =
   | { success: true; data: EmailJSResponseStatus }
   | { success: false; error: string };
 
+/**
+ * Sends the contact form through EmailJS.
+ *
+ * `captchaToken` is forwarded as `g-recaptcha-response`, the field name EmailJS looks for when
+ * reCAPTCHA verification is enabled on the template. Without it the challenge is decorative: the
+ * service id, template id and public key are all inlined into this bundle at build time (Vite
+ * exposes every VITE_ var to the client), so anyone can read them off the published site and call
+ * the API directly, never loading the form. Verifying the token server-side is what makes solving
+ * the challenge actually necessary.
+ *
+ * Enabling verification is a dashboard setting on the EmailJS template; passing the token here is
+ * the half that lives in code.
+ */
 export const sendEmail = async (
   formData: EmailFormData,
+  captchaToken: string,
 ): Promise<EmailResult> => {
   try {
     const result = await emailjs.send(
@@ -33,6 +47,7 @@ export const sendEmail = async (
         message: formData.message,
         to_name: 'Aleksandar Trenchevski',
         to_email: config.contact.email,
+        'g-recaptcha-response': captchaToken,
       },
       emailServiceConfig.publicKey,
     );


### PR DESCRIPTION
Closes the Low finding from the 2026-08-19 `security-audit` pass
(`.claude/workbench/reports/security-audit-2026-08-19.md`).

## The problem

The contact form's reCAPTCHA was decorative. `handleSubmit` blocked on
`if (!captchaValue)`, and then **threw the token away** — it was absent from the
`emailjs.send` payload, and there is no `siteverify` call anywhere in the repo.

That matters because Vite inlines `VITE_EMAILJS_SERVICE_ID`, `VITE_EMAILJS_TEMPLATE_ID` and
`VITE_EMAILJS_PUBLIC_KEY` into the published bundle — as it must, for a static site with no server.
So the ids are readable from the live page, and anyone can `POST` to the EmailJS API directly without
loading the form at all. The challenge stopped honest users and nobody else.

Impact is nuisance rather than disclosure — inbox spam and quota exhaustion. The template sends to a
fixed address, so there is nothing to redirect or read.

## What changed

- `sendEmail` takes the token and forwards it as **`g-recaptcha-response`**, the field EmailJS looks
  for when template-side reCAPTCHA verification is turned on. The SDK types `templateParams` as
  `Record<string, unknown>` (v4.4.1), so this needs no cast.
- **A second defect, found while fixing the first:** a reCAPTCHA token is single-use, and on a failed
  send the form stays mounted. Neither `captchaValue` nor the widget was cleared, so a retry
  resubmitted a spent token — which fails verification and reads as "sending is broken" rather than
  "that token was already used". Both are now reset, which required threading a ref through
  `LazyReCAPTCHA` (it did not forward one).
- While in `LazyReCAPTCHA`, removed a commented-out `className`. My own comment audit missed it —
  the scan pattern looked for commented-out *statements* and a commented JSX attribute is neither.

## Verification

- `yarn test --run` — 46/46 pass across 12 files.
- **Mutation-verified**: deleting `'g-recaptcha-response'` from the payload turns
  `emailService.test.ts` red. The assertion catches the exact defect it exists for.
- `yarn build` and `yarn lint` both clean.
- `Contact.test.tsx`'s exact `toHaveBeenCalledWith` was updated to expect the token;
  `emailService.test.ts` uses `toMatchObject`, so its params assertion was **strengthened** to pin
  the field rather than silently tolerating its absence.

## Still needed from the owner — this PR is half the fix

The code now sends the token. Verifying it is a **dashboard setting**:

1. **Enable reCAPTCHA verification** on the EmailJS template (this is what makes the token
   load-bearing rather than an ignored extra field).
2. **Turn on domain allowlisting** in the EmailJS account, restricting the public key to this origin.
   This is the higher-value half: it blocks direct API use even without a token.

Until step 1, the token is sent and ignored, which is no worse than today.