### PR TITLE
ci(cleanup): cache the monthly job's install, and fix the ordering that blocked it

### DIFF
--- a/.github/workflows/dependency-cleanup.yml
+++ b/.github/workflows/dependency-cleanup.yml
@@ -105,11 +105,20 @@ jobs:
       # ============================================================================================
 
       # --- (A) Node / TypeScript ---
+      # corepack must be enabled BEFORE setup-node, not inside the install step below:
+      # `cache: yarn` makes setup-node shell out to `yarn cache dir`, and the runner's
+      # preinstalled Yarn 1.x refuses to run in a repo pinning `packageManager: yarn@4`,
+      # so the cache step would error before the install had started.
+      - name: Enable Corepack
+        run: corepack enable
+      # node-version and cache must match ci.yml's exactly. This job runs monthly, so its
+      # own cache is always evicted before the next run - the whole win is sharing CI's.
       - uses: actions/setup-node@v7
-        with: { node-version: '24' }
+        with:
+          node-version: 24
+          cache: yarn
       - name: Install dependencies (knip needs them resolved)
         run: |
-          corepack enable || true
           if [ -f yarn.lock ]; then yarn install --immutable
           elif [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile
           else npm ci; fi


### PR DESCRIPTION
The monthly cleanup job installs the whole dependency tree so knip can resolve imports, with **no cache at all** — while `ci.yml` has cached the same install with `cache: yarn` all along.

## Adding `cache:` alone would have broken this job

That is the reason this is two changes and not one. `corepack enable` ran *inside* the install step, below `setup-node`:

```yaml
- uses: actions/setup-node@v7
  with: { node-version: '24' }          # no cache:
- name: Install dependencies (knip needs them resolved)
  run: |
    corepack enable || true             # <-- AFTER setup-node
```

`setup-node`'s `cache: yarn` shells out to `yarn cache dir` **at its own step**, and at that moment the active Yarn is the runner's preinstalled 1.x, which refuses to run in a repo pinning `packageManager: yarn@4.18.0`. The cache step would error before the install had started. So corepack becomes its own step above `setup-node` — the shape `ci.yml` already uses.

## Why `node-version` and `cache` are matched to CI exactly

A monthly workflow's own cache is **always** evicted before its next run — GitHub drops entries unused for 7 days. So the entire win here comes from *sharing CI's* cache, which only happens when the key matches, and the key is derived from the runner, the package manager and the lock. Matching CI is the feature, not a coincidence.

## Verification

The job is `workflow_dispatch`-able and report-only, so it can be run on this branch without touching anything published. Worth reading the log for: the cache key, whether it reports a hit against CI's entry, and that `yarn install --immutable` still succeeds.

Inherited from the workbench's `dependency-cleanup` template, whose Node block had both defects; fixed at source in [claude-workbench#23](https://github.com/trencho/claude-workbench/pull/23).