### PR TITLE
test: make the spent-captcha reset observable, so it can fail

### DIFF
--- a/src/components/Contact.test.tsx
+++ b/src/components/Contact.test.tsx
@@ -12,14 +12,35 @@ vi.mock('@/services/emailService', () => ({
   sendEmail: vi.fn(),
 }));
 
-// The real reCAPTCHA lazy-loads a third-party widget that never resolves in jsdom.
-// Stand in a button that hands the form a token, so the submit path is reachable.
+// A reCAPTCHA token is single-use, so the widget must be RESET after any failed send -- otherwise
+// the retry resubmits a spent token, verification fails, and it looks like sending is broken
+// rather than the token being stale.
+//
+// That reset is only observable if the mock honours `widgetRef`. It previously did not: it took
+// only `onChange`, so `recaptchaRef.current` stayed null in every test and all three
+// `recaptchaRef.current?.reset()` calls were unobservable no-ops. The reset half of the fix had no
+// test that could fail.
+const captchaReset = vi.fn();
+
+// The real component lazy-loads a third-party widget that never resolves in jsdom. This stands in
+// a button that hands the form a token, and populates the forwarded ref the way ReCAPTCHA does.
 vi.mock('./LazyReCAPTCHA', () => ({
-  default: ({ onChange }: { onChange: (value: string | null) => void }) => (
-    <button type='button' onClick={() => onChange('test-token')}>
-      complete-captcha
-    </button>
-  ),
+  default: ({
+    onChange,
+    widgetRef,
+  }: {
+    onChange: (value: string | null) => void;
+    widgetRef?: { current: { reset: () => void } | null };
+  }) => {
+    if (widgetRef) {
+      widgetRef.current = { reset: captchaReset };
+    }
+    return (
+      <button type='button' onClick={() => onChange('test-token')}>
+        complete-captcha
+      </button>
+    );
+  },
 }));
 
 const sendEmailMock = vi.mocked(sendEmail);
@@ -104,6 +125,7 @@ describe('Contact form validation', () => {
 
 describe('Contact form submission', () => {
   beforeEach(() => {
+    captchaReset.mockClear();
     sendEmailMock.mockReset();
   });
 
@@ -161,6 +183,58 @@ describe('Contact form submission', () => {
     ).toBeInTheDocument();
     // The form is still there for a retry (not swapped for the success panel).
     expect(screen.getByLabelText(/your name/i)).toBeInTheDocument();
+  });
+
+  // A reCAPTCHA token is single-use and short-lived. After a failed send the form stays mounted,
+  // so without clearing the widget the retry resubmits a token the server has already seen --
+  // verification fails and it reads as "sending is broken" rather than "the token was spent".
+  it('resets the spent captcha when the send is rejected', async () => {
+    sendEmailMock.mockResolvedValue({ success: false, error: 'rejected' });
+    const user = userEvent.setup();
+    renderContact();
+
+    await fillValidForm(user);
+    await completeCaptcha(user);
+    await submit(user);
+
+    expect(captchaReset).toHaveBeenCalledTimes(1);
+  });
+
+  // The catch branch holds the same reset pair as the failure branch above and was entirely
+  // uncovered -- it is the measured coverage regression #35 introduced.
+  it('resets the spent captcha when sending throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    sendEmailMock.mockRejectedValue(new Error('network down'));
+    const user = userEvent.setup();
+    renderContact();
+
+    await fillValidForm(user);
+    await completeCaptcha(user);
+    await submit(user);
+
+    expect(captchaReset).toHaveBeenCalledTimes(1);
+  });
+
+  // Clearing the widget is only half of it: captchaValue has to be dropped too, or the form still
+  // believes it holds a solved challenge and lets a second submit through on the spent token.
+  // Asserting the reset alone would pass with that half missing.
+  it('blocks a second submit until the captcha is solved again', async () => {
+    sendEmailMock.mockResolvedValue({ success: false, error: 'rejected' });
+    const user = userEvent.setup();
+    renderContact();
+
+    await fillValidForm(user);
+    await completeCaptcha(user);
+    await submit(user);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+    await submit(user);
+
+    // Still one call: the second submit was stopped by the missing captcha, not sent.
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText(/complete the CAPTCHA/i),
+    ).toBeInTheDocument();
   });
 
   it('resets the form when "Send another message" is clicked', async () => {


### PR DESCRIPTION
#35's reset half **had no test that could fail.**

The `LazyReCAPTCHA` mock took only `onChange` and ignored the `widgetRef` prop, so `recaptchaRef.current` was `null` in every test and all three `recaptchaRef.current?.reset()` calls were **unobservable no-ops**. The failure-path test asserted only that the form was still mounted.

## Why the reset matters

A reCAPTCHA token is **single-use and short-lived**. The form stays mounted after a failed send, so without clearing the widget the retry resubmits a token the server has already seen. Verification fails, and it reads as *"sending is broken"* rather than *"the token was spent"*.

## Three tests, covering the two halves separately

- the reset fires when the send is **rejected**;
- the reset fires when sending **throws** — that catch branch was entirely uncovered and *is* the coverage regression #35 introduced;
- a second submit is **blocked** until the captcha is solved again — which covers `setCaptchaValue(null)`, not the widget reset.

Splitting the last one out is deliberate. Clearing the widget without dropping `captchaValue` would leave the form believing it still holds a solved challenge, and an assertion on the reset alone would pass with that half missing.

## Mutation-verified, and the separation holds

| mutation | result |
|---|---|
| remove the two `handleSubmit` resets | **exactly the two reset tests fail** (2 failed, 9 passed) |
| remove `setCaptchaValue(null)` from the failure branch | **exactly the third fails** (1 failed, 10 passed) |

Each mutant kills the test that owns that half, and only that one.

`Contact.tsx` line coverage **91.89% → 97.29%**; 46 → **49** tests. Lint, coverage and build green.
