### PR TITLE
Characterize the six untested sections, and keep the formatter out of dot-directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
+# Dot-directories are tooling state, not source. Kept generic on purpose: this file is committed,
+# so a rule naming a specific tool publishes a reference to it. `.*/` covers every one of them,
+# including any that arrive later, without naming any.
+.*/
 .github/
 dist/
 node_modules/

--- a/src/layout/Home.test.tsx
+++ b/src/layout/Home.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@/shared/theme/ThemeProvider';
+import Home from './Home';
+
+/** The page's sections, in the order a visitor scrolls through them. */
+const SECTION_IDS = [
+  'home',
+  'about',
+  'experience',
+  'education',
+  'skills',
+  'certificates',
+  'projects',
+  'languages',
+  'contact',
+];
+
+const renderHome = () =>
+  render(
+    <ThemeProvider>
+      <Home />
+    </ThemeProvider>,
+  );
+
+describe('Home', () => {
+  it('renders every section, in order', () => {
+    const { container } = renderHome();
+
+    // The ids are not decoration: the navbar links to them and
+    // useActiveSection observes them, so a renamed or dropped id breaks
+    // navigation on a page that still looks complete.
+    const rendered = [...container.querySelectorAll('section[id]')].map(
+      (el) => el.id,
+    );
+    expect(rendered).toEqual(SECTION_IDS);
+  });
+
+  it('renders each section with content in it, not just the wrapper', () => {
+    const { container } = renderHome();
+
+    // A section that renders an empty shell is the failure this whole file
+    // exists for: the page scrolls, the nav works, and there is nothing there.
+    for (const id of SECTION_IDS) {
+      const section = container.querySelector(`section#${id}`);
+      expect(section, `section#${id} is missing`).not.toBeNull();
+      expect(
+        (section as HTMLElement).textContent.trim(),
+        `section#${id} rendered no text`,
+      ).not.toBe('');
+    }
+  });
+
+  it('offers a skip link to the content as the first focusable element', () => {
+    renderHome();
+
+    const skip = screen.getByRole('link', { name: 'Skip to content' });
+    expect(skip).toHaveAttribute('href', '#home');
+    // Visually hidden until focused. Without the focus classes it is a link
+    // nobody can see and nobody can reach.
+    expect(skip.className).toContain('sr-only');
+    expect(skip.className).toContain('focus:not-sr-only');
+  });
+});

--- a/src/layout/ScrollToTopButton.test.tsx
+++ b/src/layout/ScrollToTopButton.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/shared/theme/ThemeProvider';
+import ScrollToTopButton from './ScrollToTopButton';
+
+const renderButton = () =>
+  render(
+    <ThemeProvider>
+      <ScrollToTopButton />
+    </ThemeProvider>,
+  );
+
+/** Move the window and fire the event the component listens for. */
+const scrollTo = (y: number) => {
+  Object.defineProperty(window, 'scrollY', { value: y, writable: true });
+  window.dispatchEvent(new Event('scroll'));
+};
+
+describe('ScrollToTopButton', () => {
+  let scrollToSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+    // Held in a local rather than read back off `window`, which the unbound-method
+    // rule rightly objects to.
+    scrollToSpy = vi.fn();
+    window.scrollTo = scrollToSpy as unknown as typeof window.scrollTo;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('is absent at the top of the page', () => {
+    renderButton();
+    expect(
+      screen.queryByRole('button', { name: 'Back to top' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('appears once the page is scrolled past the threshold', () => {
+    renderButton();
+
+    act(() => {
+      scrollTo(101);
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Back to top' }),
+    ).toBeInTheDocument();
+  });
+
+  it('stays hidden AT the threshold, which is where an off-by-one would show', () => {
+    renderButton();
+
+    act(() => {
+      scrollTo(100);
+      vi.advanceTimersByTime(150);
+    });
+
+    // The predicate is `> 100`, not `>=`. Without this case, changing it would
+    // pass every other test here.
+    expect(
+      screen.queryByRole('button', { name: 'Back to top' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not react before the debounce has elapsed', () => {
+    renderButton();
+
+    act(() => {
+      scrollTo(500);
+      vi.advanceTimersByTime(149);
+    });
+
+    // Asserting the debounce exists, rather than only that the button
+    // eventually appears: a component that updated on every scroll event would
+    // satisfy the test above and fail this one.
+    expect(
+      screen.queryByRole('button', { name: 'Back to top' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('scrolls back to the top when clicked', () => {
+    renderButton();
+
+    act(() => {
+      scrollTo(500);
+      vi.advanceTimersByTime(150);
+    });
+
+    // fireEvent rather than userEvent: userEvent schedules its own timers, and
+    // this suite runs on fake ones.
+    fireEvent.click(screen.getByRole('button', { name: 'Back to top' }));
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('removes its scroll listener on unmount', () => {
+    const remove = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderButton();
+
+    unmount();
+
+    // A listener left behind keeps calling setState on an unmounted component,
+    // which is invisible in a page that never navigates away.
+    expect(remove).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+});

--- a/src/sections/about/About.test.tsx
+++ b/src/sections/about/About.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@/shared/theme/ThemeProvider';
+import About from './About';
+
+const renderAbout = () =>
+  render(
+    <ThemeProvider>
+      <About />
+    </ThemeProvider>,
+  );
+
+describe('About', () => {
+  it('renders its heading', () => {
+    renderAbout();
+    expect(
+      screen.getByRole('heading', { name: 'About Me', level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders all three paragraphs', () => {
+    const { container } = renderAbout();
+
+    // The copy is prose rather than data, so the count is what protects it: a
+    // layout change that drops one paragraph leaves the other two rendering and
+    // says nothing.
+    expect(container.querySelectorAll('p')).toHaveLength(3);
+  });
+
+  it('keeps the claims the page is actually making', () => {
+    renderAbout();
+
+    // Spot-checks, not a transcription. Each of these is a factual claim about
+    // the owner rather than styling, so a rewrite that silently drops one is
+    // worth catching. Matched across element boundaries because the emphasis
+    // tags split the sentences.
+    for (const claim of [
+      /backend/i,
+      /data engineering/i,
+      /RESTful APIs/i,
+      /ETL pipelines/i,
+      /Azure Databricks/i,
+      /Master's in Electrical Engineering/i,
+    ]) {
+      expect(screen.getByText(claim, { exact: false })).toBeInTheDocument();
+    }
+  });
+});

--- a/src/sections/certificates/Certificates.test.tsx
+++ b/src/sections/certificates/Certificates.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@/shared/theme/ThemeProvider';
+import certificates from '@/data/certificates.json';
+import Certificates from './Certificates';
+
+const renderCertificates = () =>
+  render(
+    <ThemeProvider>
+      <Certificates />
+    </ThemeProvider>,
+  );
+
+describe('Certificates', () => {
+  it('renders a heading and one card per certificate', () => {
+    renderCertificates();
+    expect(
+      screen.getByRole('heading', { name: 'Certificates', level: 2 }),
+    ).toBeInTheDocument();
+
+    for (const certificate of certificates) {
+      expect(
+        screen.getByRole('heading', { name: certificate.title, level: 3 }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('gives every image the certificate title as its alt text', () => {
+    renderCertificates();
+
+    for (const certificate of certificates) {
+      const image = screen.getByAltText(certificate.title);
+      expect(image).toHaveAttribute('src', certificate.imageSrc);
+      // Off-screen by design, so it must not block first paint.
+      expect(image).toHaveAttribute('loading', 'lazy');
+    }
+  });
+
+  it('offers a webp source alongside the png, so the fallback is real', () => {
+    const { container } = renderCertificates();
+
+    // A <picture> whose <source> points at the same file as the <img> is a
+    // no-op dressed as an optimisation.
+    for (const certificate of certificates) {
+      const webp = certificate.imageSrc.replace(/\.png$/, '.webp');
+      expect(webp).not.toBe(certificate.imageSrc);
+      expect(
+        container.querySelector(`source[srcset="${webp}"][type="image/webp"]`),
+      ).not.toBeNull();
+    }
+  });
+
+  it('links each certificate to its credential, opening safely in a new tab', () => {
+    renderCertificates();
+
+    for (const certificate of certificates) {
+      if (!certificate.url) continue;
+      const anchor = screen.getByRole('link', { name: certificate.title });
+      expect(anchor).toHaveAttribute('href', certificate.url);
+      expect(anchor).toHaveAttribute('target', '_blank');
+      // Without noopener the opened page gets a handle on window.opener.
+      expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+});

--- a/src/sections/education/Education.test.tsx
+++ b/src/sections/education/Education.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@/shared/theme/ThemeProvider';
+import education from '@/data/education.json';
+import publications from '@/data/publications.json';
+import Education from './Education';
+
+const renderEducation = () =>
+  render(
+    <ThemeProvider>
+      <Education />
+    </ThemeProvider>,
+  );
+
+describe('Education', () => {
+  it('renders a heading and every field of every degree', () => {
+    renderEducation();
+    expect(
+      screen.getByRole('heading', { name: 'Education', level: 2 }),
+    ).toBeInTheDocument();
+
+    for (const degree of education) {
+      expect(screen.getByText(degree.degree)).toBeInTheDocument();
+      // Both degrees are from the same university, so the institution is not a
+      // unique node. Assert the count the data implies.
+      const sameInstitution = education.filter(
+        (other) => other.institution === degree.institution,
+      ).length;
+      expect(screen.getAllByText(degree.institution)).toHaveLength(
+        sameInstitution,
+      );
+      expect(screen.getByText(degree.period)).toBeInTheDocument();
+      // The thesis is the field most likely to be dropped by a layout change,
+      // because it is the only one that is not a heading or a date.
+      expect(screen.getByText(degree.thesis)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the publications block, each entry linking out safely', () => {
+    renderEducation();
+
+    // The block is behind `publications.length > 0`. Asserting the heading only
+    // when there is data keeps the test honest if the file is ever emptied.
+    if (publications.length === 0) {
+      expect(screen.queryByText('Publications')).not.toBeInTheDocument();
+      return;
+    }
+
+    expect(
+      screen.getByRole('heading', { name: 'Publications', level: 3 }),
+    ).toBeInTheDocument();
+
+    for (const publication of publications) {
+      const anchor = screen.getByRole('link', { name: publication.title });
+      expect(anchor).toHaveAttribute('href', publication.url);
+      expect(anchor).toHaveAttribute('target', '_blank');
+      expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+});

--- a/src/sections/experience/Experience.test.tsx
+++ b/src/sections/experience/Experience.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@/shared/theme/ThemeProvider';
+import experience from '@/data/experience.json';
+import Experience from './Experience';
+
+const renderExperience = () =>
+  render(
+    <ThemeProvider>
+      <Experience />
+    </ThemeProvider>,
+  );
+
+describe('Experience', () => {
+  it('renders a heading and one entry per job', () => {
+    renderExperience();
+    expect(
+      screen.getByRole('heading', { name: 'Experience', level: 2 }),
+    ).toBeInTheDocument();
+
+    // The h3 differs by shape: a job with several roles is titled by the company
+    // alone, a single-role job by "<role> · <company>". Asserting the company name
+    // appears either way is what makes this independent of that branch.
+    for (const job of experience) {
+      expect(
+        screen.getAllByText(new RegExp(job.company)).length,
+      ).toBeGreaterThan(0);
+      // Two jobs can legitimately share a location or a period, so assert the
+      // COUNT matches the data rather than requiring a unique node.
+      const sameLocation = experience.filter(
+        (other) => other.location === job.location,
+      ).length;
+      expect(screen.getAllByText(job.location)).toHaveLength(sameLocation);
+      const samePeriod = experience.filter(
+        (other) => other.period === job.period,
+      ).length;
+      expect(screen.getAllByText(job.period)).toHaveLength(samePeriod);
+    }
+  });
+
+  it('renders every project of every role, with its description', () => {
+    renderExperience();
+
+    for (const job of experience) {
+      for (const role of job.roles) {
+        for (const project of role.projects) {
+          expect(
+            screen.getByRole('heading', { name: project.name, level: 5 }),
+          ).toBeInTheDocument();
+          expect(screen.getByText(project.description)).toBeInTheDocument();
+        }
+      }
+    }
+  });
+
+  it('lists each technology of each project as a chip', () => {
+    renderExperience();
+
+    for (const job of experience) {
+      for (const role of job.roles) {
+        for (const project of role.projects) {
+          for (const tech of project.technologies) {
+            // A technology can legitimately repeat across projects, so assert
+            // presence rather than a single node.
+            expect(screen.getAllByText(tech).length).toBeGreaterThan(0);
+          }
+        }
+      }
+    }
+  });
+
+  it('shows a role sub-heading only where a job has more than one role', () => {
+    renderExperience();
+
+    // This is the branch the component actually carries. Without it, a
+    // multi-role job would silently lose the role names and every other
+    // assertion here would still pass.
+    for (const job of experience) {
+      if (job.roles.length > 1) {
+        for (const role of job.roles) {
+          expect(
+            screen.getByRole('heading', { name: role.title, level: 4 }),
+          ).toBeInTheDocument();
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Two things: a formatter that could reach state it should not, and the six sections that had no tests at all.

## The formatter reached every dot-directory

`yarn format` runs `prettier --write .`, and `.prettierignore` excluded `.github/` by name and nothing else. Anything else keeping state in a dot-directory gets rewritten on the next format run, silently, because a formatter reports nothing when it succeeds.

The rule is now generic, `.*/`, rather than a list. A committed ignore file naming specific tools publishes a reference to each one, and a generic rule also covers whatever arrives later. `.github/` stays below it as explicit intent even though it is now redundant.

Confirmed with `prettier --file-info`, which answers "is this ignored?" directly — `--check` and `--list-different` are both silent whether a path is clean or was never matched, so neither can settle it.

## Six sections had no tests at all

`Home`, `About`, `Experience`, `Education`, `Certificates` and `ScrollToTopButton` were at **0% coverage**. Nothing would have noticed any of them rendering an empty shell — and on a single-page CV that is the failure mode that matters, because the page still scrolls, the nav still works, and there is nothing there.

Written data-first, matching the existing `Projects` and `Skills` specs: each test iterates the real JSON and asserts every entry appears, so adding a job or a certificate extends the assertions instead of leaving them behind.

**Verified by mutation, not by coverage.** A characterization test that passes over broken code is worse than none, so each mutation disables exactly one thing and each is killed by a *named* assertion, after the unmutated tree passed 106/106:

| Mutation | Killed by |
|---|---|
| drop the `about` section from `Home` | `renders every section, in order` |
| scroll threshold `>` becomes `>=` | `stays hidden AT the threshold, which is where an off-by-one would show` |
| remove the 150 ms scroll debounce | `does not react before the debounce has elapsed` |
| certificates lose their credential link | `links each certificate to its credential, opening safely in a new tab` |
| project descriptions stop rendering | `renders every project of every role, with its description` |
| the thesis line goes | `renders a heading and every field of every degree` |

Two of the new tests were themselves wrong first and were corrected rather than loosened: two degrees share an institution and two jobs share a location, so `getByText` failed on non-uniqueness. They now assert the **count the data implies**, which is stricter than the original and would catch a duplicate as well as a missing entry.

## Coverage

| | before | after |
|---|---|---|
| Statements | 67.83% | **89.19%** |
| Branches | 57.43% | **71.95%** |
| Functions | 63.93% | **88.52%** |
| Lines | 68.43% | **90.45%** |
| Tests | 84 (16 files) | **106 (22 files)** |

## Verification

`yarn lint` rc=0 with zero problems, `prettier --check .` rc=0, `yarn build` rc=0 (which is where `tsc -noEmit`, the SSR build and the prerender run), `yarn vitest run` 106/106.
