### PR TITLE
Give the scan a concurrency group, like every other scan in the fleet

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,6 +17,17 @@ permissions:
   contents: read
   security-events: write
 
+# Every other scan in the fleet has this and this one did not, so a second push to the same ref
+# queued a whole extra scan instead of superseding the first. Grouped by ref and cancelling, which
+# is the shape the siblings use.
+#
+# Safe here despite the SARIF upload: the group is per-ref, so the run that survives is the LATER
+# one on that ref, and it uploads the newer result. A cancelled run uploads nothing, which is
+# correct -- its result is already stale.
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Found by a parity check across all eleven repos: this was the **only** `security-scan.yml` without a `concurrency` block, so a second push to the same ref queued a whole extra scan instead of superseding the first.

Grouped by ref and cancelling, matching the shape every sibling uses:

```yaml
concurrency:
  group: security-scan-${{ github.ref }}
  cancel-in-progress: true
```

**Safe despite the SARIF upload**, which is the one thing worth checking here. The group is per-ref, so the run that survives is the *later* one on that ref and it uploads the newer result. A cancelled run uploads nothing — which is correct, because its result is already stale.

The `push` trigger stays, unlike the other five repos where it was dropped: this scan uses the OSV reusable workflows and its default-branch run is what refreshes and **closes** code-scanning alerts.