### PR TITLE
test: parse index.html instead of pattern-matching its script tags

### DIFF
--- a/src/shared/theme/prePaintTheme.test.ts
+++ b/src/shared/theme/prePaintTheme.test.ts
@@ -17,12 +17,23 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const html = readFileSync(join(process.cwd(), 'index.html'), 'utf8');
 
-// Only the bare `<script>` matches; the JSON-LD blocks and the module entry both carry
-// attributes.
-const inlineScripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(
-  (m) => m[1],
-);
-const prePaintScript = inlineScripts.find((s) => s?.includes('darkMode'));
+// Parsed rather than pattern-matched. Picking tags out of HTML with a regular
+// expression is fragile in ways that are easy to miss - case, attribute order,
+// a `>` inside a string - and CodeQL flags the shape (js/bad-tag-filter) whether
+// or not the input is trusted. jsdom is already the test environment, so the
+// document can just be read.
+//
+// The pre-paint script is the inline one: no `src`, no `type` (which excludes the
+// JSON-LD blocks and the module entry), and it is the one that reads `darkMode`.
+const inlineScripts = [
+  ...new DOMParser()
+    .parseFromString(html, 'text/html')
+    .querySelectorAll('script'),
+]
+  .filter((script) => !script.src && !script.type)
+  .map((script) => script.textContent);
+
+const prePaintScript = inlineScripts.find((s) => s.includes('darkMode'));
 
 const setOsPrefersDark = (prefersDark: boolean) => {
   Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
CodeQL flagged the tag extraction in `prePaintTheme.test.ts` as **`js/bad-tag-filter`, high severity**: picking tags out of HTML with a regular expression misses case variants, and that one would not have matched `<SCRIPT>`.

Not exploitable — the input is a file in this repo and the regex is not a sanitiser — but the weakness is real, and the fix is cheap. jsdom is already the test environment, so the document is parsed and queried instead. The pre-paint script is identified structurally: the inline one with no `src` and no `type` (which excludes the JSON-LD blocks and the module entry), and which reads `darkMode`.

## Why this is a separate PR, and how it was nearly lost

The alert is **live on master**, created `2026-09-06T23:44:42Z` in a file #50 added. I merged #50 while that alert was open, having misread the failure: I queried the code-scanning alerts without filtering by tool, found two `brace-expansion` entries, established they were stale and pre-existing, and concluded the CodeQL failure was those. It was not — those are `TOOL=osv-scanner` from 2026-07-26. The failing check was `TOOL=CodeQL`, and its alert was the new one.

The brace-expansion analysis was accurate about brace-expansion and irrelevant to the check that was red.

`#51` carried this same commit but conflicted, because #50 was squash-merged and the branch's base no longer existed. This is a clean cherry-pick onto master; #51 is closed.

## Verification

`yarn coverage`: **153 tests passed**, statements 89.48%, branches 75.23% — unchanged, which is the point: this changes how the test reads the file, not what it asserts.