### PR TITLE
chore(deps): move vitest and its coverage provider in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,23 @@ updates:
       prefix: "chore"
       include: "scope"
     groups:
+      # vitest and its coverage provider peer each other at an EXACT version -- @vitest/coverage-v8
+      # requests `vitest: "5.0.0"`, not a range -- so they have to move in the same PR on every
+      # release, majors included. Listed FIRST, because a dependency joins the first group it
+      # matches, and with NO update-types filter, because that is what makes a group take every
+      # type. minor-and-patch alone left the major path ungrouped, which is the case that splits
+      # them.
+      #
+      # What a split costs, measured here on 2026-09-07 rather than assumed: PRs #54 and #55 each
+      # paired v5 of one package with v4 of the other. Yarn reports the unmet exact peer as a
+      # YN0060 WARNING, so the install exits 0 and lint, test and build all pass -- then coverage
+      # collection dies inside takeCoverage and every file reports 0%, failing the thresholds.
+      # The failure surfaces as a coverage error, which reads like a test problem rather than a
+      # dependency one.
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       minor-and-patch:
         update-types:
           - "minor"


### PR DESCRIPTION
`@vitest/coverage-v8` peers `vitest` at an **exact** version, not a range, so the two have to move together. Without a group Dependabot opened them separately — #54 and #55 — and both fail CI:

```
YN0060: vitest is listed with version 5.0.0,
        which doesn't satisfy what @vitest/coverage-v8 requests (4.1.11).
...
ERROR: Coverage for lines (0%) does not meet global threshold (85%)
```

Yarn treats the unmet exact peer as a *warning*, so the install exits 0 and lint, test and build all pass. Only coverage breaks, reporting 0% for every file — which reads as a test problem rather than a dependency one.

The group is listed **first** (a dependency joins the first group it matches) and carries **no** `update-types` filter (that is what makes a group take majors).

Same config already ships in `task-manager-frontend` and `crowd-tune-frontend`; this repo and `aqra-frontend` were the two it had not reached.

After merge, #54 and #55 need closing so Dependabot can reopen them as one grouped PR — while a package has its own open PR, Dependabot leaves it out of the group.
